### PR TITLE
Fixed missing unquote for links.

### DIFF
--- a/riakasaurus/riak_object.py
+++ b/riakasaurus/riak_object.py
@@ -6,6 +6,7 @@
 import re
 import json
 import csv
+import urllib
 from twisted.internet import defer
 
 from riakasaurus import util, mapreduce, riak_link, riak_index_entry
@@ -536,8 +537,9 @@ class RiakObject(object):
                  "\<\/([^\/]+)\/([^\/]+)\/([^\/]+)\>; ?riaktag=\"([^\']+)\"",
                  link_header)
             if (matches != None):
-                link = riak_link.RiakLink(matches.group(2), matches.group(3),
-                                matches.group(4))
+                link = riak_link.RiakLink(urllib.unquote_plus(matches.group(2)),
+                                          urllib.unquote_plus(matches.group(3)),
+                                          urllib.unquote_plus(matches.group(4)))
                 self._links.append(link)
 
         return self

--- a/riakasaurus/tests.py
+++ b/riakasaurus/tests.py
@@ -517,10 +517,12 @@ class RiakTestCase1(unittest.TestCase):
         # so there's now something wrong with link storage.
         log.msg('*** store_and_get_links')
 
+        quote_string = "tag2!@#%^&*)"
+
         obj = self.bucket.new("foo", 2) \
                 .add_link(self.bucket.new("foo1")) \
                 .add_link(self.bucket.new("foo2"), "tag") \
-                .add_link(self.bucket.new("foo3"), "tag2!@#%^&*)")
+                .add_link(self.bucket.new(quote_string), quote_string)
         yield obj.store()
         del obj
 
@@ -528,6 +530,11 @@ class RiakTestCase1(unittest.TestCase):
         obj = yield self.bucket.get("foo")
         links = obj.get_links()
         self.assertEqual(len(links), 3)
+
+        quote_link = links[-1]
+        self.assertEqual(quote_link.get_key(), quote_string)
+        self.assertEqual(quote_link.get_tag(), quote_string)
+
         log.msg('done store_and_get_links')
 
     @defer.inlineCallbacks


### PR DESCRIPTION
Quoted keys and tags were prior given back on links.
Further bug resulting of this one was multiple encoded keys/tags.
