### PR TITLE
support for bucket.head() metadata request

### DIFF
--- a/riakasaurus/bucket.py
+++ b/riakasaurus/bucket.py
@@ -318,6 +318,24 @@ class RiakBucket(object):
         pr = self.get_pr(pr)
         return obj.reload(r=r, pr=pr)
 
+    def head(self, key, r=None, pr=None):
+        """
+        Retrieve a JSON-encoded object from Riak.
+
+        :param key: Name of the key.
+        :type key: string
+        :param r: R-Value of the request (defaults to bucket's R)
+        :type r: integer
+        :param pr: PR-Value of the request (defaults to bucket's PR)
+        :type pr: integer
+        :rtype: :class:`RiakObject <riak.riak_object.RiakObject>`
+        """
+        obj = RiakObject(self._client, self, key)
+        obj._encode_data = True
+        r = self.get_r(r)
+        pr = self.get_pr(pr)
+        return obj.head(r=r, pr=pr)
+    
     def get_binary(self, key, r=None, pr=None):
         """
         Retrieve a binary/string object from Riak.

--- a/riakasaurus/riak_object.py
+++ b/riakasaurus/riak_object.py
@@ -466,7 +466,7 @@ class RiakObject(object):
         r = self._bucket.get_r(r)
         pr = self._bucket.get_pr(pr)
         t = self._client.get_transport()
-        Result = yield t.get(self, r=r, pr=pr, vtag=vtag, method='HEAD')
+        Result = yield t.head(self, r=r, pr=pr, vtag=vtag)
 
         self.clear()
         if Result is not None:

--- a/riakasaurus/riak_object.py
+++ b/riakasaurus/riak_object.py
@@ -451,6 +451,30 @@ class RiakObject(object):
         defer.returnValue(self)
 
     @defer.inlineCallbacks
+    def head(self, r=None, pr=None, vtag=None):
+        """
+        Loads the metadata from Riak. When this operation completes, the
+        object could contain new metadata if the object was updated in Riak
+        since it was last retrieved. No Data will be fetched.
+
+        :param r: R-Value, wait for this many partitions to respond
+         before returning to client.
+        :type r: integer
+        :rtype: self
+        """
+        # Do the request...
+        r = self._bucket.get_r(r)
+        pr = self._bucket.get_pr(pr)
+        t = self._client.get_transport()
+        Result = yield t.get(self, r=r, pr=pr, vtag=vtag, method='HEAD')
+
+        self.clear()
+        if Result is not None:
+            self.populate(Result)
+
+        defer.returnValue(self)
+
+    @defer.inlineCallbacks
     def delete(self, rw=None, r=None, w=None, dw=None, pr=None, pw=None):
         """
         Delete this object from Riak.
@@ -532,7 +556,8 @@ class RiakObject(object):
                 if not metadata.has_key(MD_INDEX):
                     metadata[MD_INDEX] = []
                 self.set_metadata(metadata)
-                self.set_encoded_data(data)
+                if data:        # needed for HEAD support
+                    self.set_encoded_data(data)
                 # Create objects for all siblings
                 siblings = [self]
                 for (metadata, data) in contents:

--- a/riakasaurus/tests.py
+++ b/riakasaurus/tests.py
@@ -91,6 +91,20 @@ class Tests(unittest.TestCase):
         log.msg("done secondary_index")
 
     @defer.inlineCallbacks
+    def test_head(self):
+        """create a object, and retrieve metadata via head(), no content is loaded"""
+        log.msg("*** head")
+
+        obj = self.bucket.new("foo1", "test1")
+        yield obj.store()
+        
+        obj = yield self.bucket.head("foo1")
+        self.assertEqual(obj.exists(), True)
+        self.assertEqual(obj.get_data(), None)
+
+        log.msg("done head")
+
+    @defer.inlineCallbacks
     def test_set_data_empty(self):
         """Get an object that does not exist, then set_data and save it """
         log.msg("*** set_data_empty")
@@ -103,6 +117,7 @@ class Tests(unittest.TestCase):
         obj.set_data('bar1')
         yield obj.store()
 
+        
         self.assertEqual(obj.exists(), True)
         self.assertEqual(obj.get_data(), "bar1")
         log.msg("done set_data_empty")

--- a/riakasaurus/transport.py
+++ b/riakasaurus/transport.py
@@ -321,7 +321,7 @@ class HTTPTransport(FeatureDetection):
             defer.returnValue({})
 
     @defer.inlineCallbacks
-    def get(self, robj, r = None, pr = None, vtag = None, method='GET') :
+    def get(self, robj, r = None, pr = None, vtag = None) :
         """
         Get a bucket/key from the server
         """
@@ -332,11 +332,27 @@ class HTTPTransport(FeatureDetection):
             params['vtag'] = vtag
         url = self.build_rest_path(robj.get_bucket(), robj.get_key(),
                                    params=params)
-        response = yield self.http_request(method, url)
+        response = yield self.http_request('GET', url)
         defer.returnValue(
             self.parse_body(response, [200, 300, 404])
         )
 
+    @defer.inlineCallbacks
+    def head(self, robj, r = None, pr = None, vtag = None) :
+        """
+        Get metadata for a bucket/key from the server, basically
+        the same as get() but retrieves no data
+        """
+        params = {'r' : r, 'pr': pr}
+        if vtag is not None:
+            params['vtag'] = vtag
+        url = self.build_rest_path(robj.get_bucket(), robj.get_key(),
+                                   params=params)
+        response = yield self.http_request('HEAD', url)
+        defer.returnValue(
+            self.parse_body(response, [200, 300, 404])
+        )
+        
         
     def put(self, robj, w = None, dw = None, pw = None, return_body = True, if_none_match=False):
         """

--- a/riakasaurus/transport.py
+++ b/riakasaurus/transport.py
@@ -321,7 +321,7 @@ class HTTPTransport(FeatureDetection):
             defer.returnValue({})
 
     @defer.inlineCallbacks
-    def get(self, robj, r = None, pr = None, vtag = None) :
+    def get(self, robj, r = None, pr = None, vtag = None, method='GET') :
         """
         Get a bucket/key from the server
         """
@@ -332,11 +332,12 @@ class HTTPTransport(FeatureDetection):
             params['vtag'] = vtag
         url = self.build_rest_path(robj.get_bucket(), robj.get_key(),
                                    params=params)
-        response = yield self.http_request('GET', url)
+        response = yield self.http_request(method, url)
         defer.returnValue(
             self.parse_body(response, [200, 300, 404])
         )
 
+        
     def put(self, robj, w = None, dw = None, pw = None, return_body = True, if_none_match=False):
         """
         Serialize put request and deserialize response


### PR DESCRIPTION
this implements a bucket.head() method that retrieves only metadata for a existing key using HTTP HEAD /... instead of HTTP GET /... 
The rationale behind is that this is much more lightweight method  if one wants to check if a key exists or wants to retrieve a vclock for updating, especially with bigger contents
