### PR TITLE
Http timeout

### DIFF
--- a/riakasaurus/exc.py
+++ b/riakasaurus/exc.py
@@ -1,0 +1,3 @@
+class TimeoutError(Exception):
+    ''' Raised to notify that an operation exceeded its timeout. '''
+

--- a/riakasaurus/transport.py
+++ b/riakasaurus/transport.py
@@ -1027,6 +1027,7 @@ class PBCTransport(FeatureDetection):
             if stp.isIdle():
                 stp.setActive()
                 foundOne = True
+                stp.getTransport().setTimeout(self.timeout)
                 if self.debug & LOGLEVEL_TRANSPORT_VERBOSE:
                     log.msg("[%s] aquired idle transport[%d]: %s" % (self.__class__.__name__, len(self._transports),stp), logLevel = self.logToLevel)
                 defer.returnValue(stp)

--- a/riakasaurus/transport.py
+++ b/riakasaurus/transport.py
@@ -26,6 +26,7 @@ from twisted.web.client import Agent
 
 from riakasaurus.riak_index_entry import RiakIndexEntry
 from riakasaurus.mapreduce import RiakLink
+from riakasaurus.exc import TimeoutError
 
 # protobuf
 from riakasaurus.tx_riak_pb import RiakPBCClient
@@ -43,10 +44,6 @@ versions = {
     1.1: StrictVersion("1.1.0"),
     1.2: StrictVersion("1.2.0")
     }
-
-
-class TimeoutError(Exception):
-    pass
 
 
 class ITransport(Interface):

--- a/riakasaurus/tx_riak_pb.py
+++ b/riakasaurus/tx_riak_pb.py
@@ -306,7 +306,7 @@ class RiakPBC(Int32StringReceiver):
             msg = code
         self.sendString(msg)
         self.factory.d = Deferred()
-        if self.timeout:
+        if self.timeout is not None:
             self.timeoutd = reactor.callLater(self.timeout, self._triggerTimeout)
 
         return self.factory.d

--- a/riakasaurus/tx_riak_pb.py
+++ b/riakasaurus/tx_riak_pb.py
@@ -11,6 +11,7 @@ from pprint import pformat
 # generated code from *.proto message definitions
 from riak_kv_pb2 import *
 from riak_pb2 import *
+from exc import TimeoutError
 
 ## Protocol codes
 MSG_CODE_ERROR_RESP = 0
@@ -47,6 +48,10 @@ MSG_CODE_SEARCH_QUERY_RESP = 28
 
 class RiakPBCException(Exception):
     pass
+
+class RiakPBCTimeoutError(RiakPBCException, TimeoutError):
+    pass
+
 
 def toHex(s):
     lst = []
@@ -314,7 +319,7 @@ class RiakPBC(Int32StringReceiver):
     def _triggerTimeout(self):
         if not self.factory.d.called:
             try:
-                self.factory.d.errback(RiakPBCException('timeout'))
+                self.factory.d.errback(RiakPBCTimeoutError('timeout'))
             except Exception, e:
                 print "Unable to handle Timeout: %s" % e
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -11,7 +11,7 @@ from twisted.internet import defer
 
 VERBOSE = False
 
-from riakasaurus import riak, transport
+from riakasaurus import riak, exc
 
 # uncomment to activate logging
 # import sys
@@ -117,7 +117,7 @@ class Tests(unittest.TestCase):
         self.client.get_transport().setTimeout(0)
         try:
             yield self.bucket.get('foo')
-        except transport.TimeoutError:
+        except exc.TimeoutError:
             pass
         else:
             assert False, 'request did not time out.'
@@ -126,7 +126,7 @@ class Tests(unittest.TestCase):
         self.client.get_transport().setTimeout(1)
         try:
             yield self.bucket.get('foo')
-        except transport.TimeoutError:
+        except exc.TimeoutError:
             assert False, 'request timed out unexpectedly.'
 
         self.client.get_transport().setTimeout(None)


### PR DESCRIPTION
Add the ability to fail HTTP operations that take too long, just like is already in place for PBC. I also added a TimeoutError exception and made sure tht both HTTP and PBC transports will use it, so that you can use them interchangeably.
