### PR TITLE
Fix PBC problem with transports hanging on connection refused

### DIFF
--- a/riakasaurus/tests/test_pbc.py
+++ b/riakasaurus/tests/test_pbc.py
@@ -6,6 +6,7 @@ tests for RiakPBCClient, trial
 from twisted.trial import unittest
 from twisted.internet import defer
 from twisted.python import log
+from twisted.internet.error import ConnectionRefusedError
 
 from riakasaurus.transport import pbc
 
@@ -186,3 +187,12 @@ class Test_PBCClient(unittest.TestCase):
         self.assertTrue(len(result.content[0].links) == 2)
 
         log.msg("done testing links")
+
+    @defer.inlineCallbacks
+    def test_connection_refused(self):
+        try:
+            # Connection to a host that does not exist.
+            yield pbc.RiakPBCClient().connect('127.0.0.17', 8087)
+            assert False, 'ConnectionRefusedError not raised as expected.'
+        except ConnectionRefusedError:
+            pass

--- a/riakasaurus/transport/pbc/__init__.py
+++ b/riakasaurus/transport/pbc/__init__.py
@@ -478,6 +478,9 @@ class RiakPBCClientFactory(ClientFactory):
         self.d = Deferred()
         self.connected = Deferred()
 
+    def clientConnectionFailed(self, connector, reason):
+        self.connected.errback(reason)
+
 
 class RiakPBCClient(object):
     def connect(self, host, port):


### PR DESCRIPTION
If a connection attempt is refused, Twisted calls the
clientConnectionFailed method of the client factory to determine what to
do. The default behaviour is to do nothing, thereby hanging the
connection. This patch changes the behaviour of RiakPBCClientFactory so
that the error is passed back to whoever initiated the connection in the
first place.
