### PR TITLE
Fix leaking of transports due to connection lost

### DIFF
--- a/riakasaurus/transport/pbc/__init__.py
+++ b/riakasaurus/transport/pbc/__init__.py
@@ -147,6 +147,7 @@ class RiakPBC(Int32StringReceiver):
 
     timeout = None
     timeoutd = None
+    disconnected = False
     debug = 0
 
     # ------------------------------------------------------------------
@@ -344,6 +345,9 @@ class RiakPBC(Int32StringReceiver):
         """
         self.factory.connected.callback(self)
 
+    def connectionLost(self, reason):
+        self.disconnected = True
+
     def setTimeout(self, t):
         self.timeout = t
 
@@ -464,6 +468,9 @@ class RiakPBC(Int32StringReceiver):
                 raise exceptions.RiakPBCException('invalid value %s' % (val))
         else:
             return val
+
+    def isDisconnected(self):
+        return self.disconnected
 
     @defer.inlineCallbacks
     def quit(self):

--- a/riakasaurus/transport/pbc_transport.py
+++ b/riakasaurus/transport/pbc_transport.py
@@ -66,6 +66,10 @@ class StatefulTransport(object):
     def age(self):
         return time.time() - self.__used
 
+    def isDisconnected(self):
+        transport = self.getTransport()
+        return transport and transport.isDisconnected()
+
 
 class PBCTransport(transport.FeatureDetection):
     """ Protocoll buffer transport for Riak """
@@ -96,6 +100,10 @@ class PBCTransport(transport.FeatureDetection):
     @defer.inlineCallbacks
     def _getFreeTransport(self):
         foundOne = False
+
+        # Discard disconnected transports.
+        self._transports = [x for x in self._transports if not x.isDisconnected()]
+
         for stp in self._transports:
             if stp.isIdle():
                 stp.setActive()


### PR DESCRIPTION
When a connection is broken the connectionLost method of the transport is
called. The default behaviour is to do nothing. This patch overrides it
to store the new state on the transport. The transport is then garbage
collected the next time _getFreeTransport is called.

Unfortunately I haven't been able to write any tests to prove that this fixes the problem, but I have been testing it out on my own system by stopping and then restarting one of my Riak nodes.
