### PR TITLE
Replace StrictVersion with LooseVersion

### DIFF
--- a/riakasaurus/tests/test_basic.py
+++ b/riakasaurus/tests/test_basic.py
@@ -8,7 +8,7 @@ riakasaurus _must_ be on your PYTHONPATH
 from twisted.trial import unittest
 from twisted.python import log
 from twisted.internet import defer
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 
 VERBOSE = False
 
@@ -146,7 +146,7 @@ class Tests_HTTP(unittest.TestCase, BasicTestsMixin):
         """manipulate bucket properties"""
         log.msg('*** reset_bucket_properties_not_available')
         self.patch(self.client.transport, 'server_version',
-            lambda: StrictVersion('1.2.0'))
+                   lambda: LooseVersion('1.2.0'))
         try:
             # Test resetting bucket properties...
             yield self.bucket.reset_properties()

--- a/riakasaurus/transport/http_transport.py
+++ b/riakasaurus/transport/http_transport.py
@@ -17,7 +17,7 @@ from riakasaurus.mapreduce import RiakLink
 from riakasaurus.transport import transport
 from riakasaurus import exceptions
 
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 from cStringIO import StringIO
 from xml.etree import ElementTree
 

--- a/riakasaurus/transport/pbc_transport.py
+++ b/riakasaurus/transport/pbc_transport.py
@@ -7,7 +7,7 @@ from twisted.internet import defer, reactor, protocol
 from twisted.python import log
 import logging
 
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 
 import time
 
@@ -327,7 +327,7 @@ class PBCTransport(transport.FeatureDetection):
         if not self._s_version:
             self._s_version = yield self._server_version()
 
-        defer.returnValue(StrictVersion(self._s_version))
+        defer.returnValue(LooseVersion(self._s_version))
 
     @defer.inlineCallbacks
     def _server_version(self):

--- a/riakasaurus/transport/transport.py
+++ b/riakasaurus/transport/transport.py
@@ -2,13 +2,13 @@ from zope.interface import Interface
 
 from twisted.internet import defer
 
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 
 versions = {
-    1: StrictVersion("1.0.0"),
-    1.1: StrictVersion("1.1.0"),
-    1.2: StrictVersion("1.2.0"),
-    1.3: StrictVersion("1.3.0"),
+    1: LooseVersion("1.0.0"),
+    1.1: LooseVersion("1.1.0"),
+    1.2: LooseVersion("1.2.0"),
+    1.3: LooseVersion("1.3.0"),
     }
 
 
@@ -166,4 +166,4 @@ class FeatureDetection(object):
         if not self._s_version:
             self._s_version = yield self._server_version()
 
-        defer.returnValue(StrictVersion(self._s_version))
+        defer.returnValue(LooseVersion(self._s_version))


### PR DESCRIPTION
Some builds of riak report loose version numbers (e.g. `1.4.2-0-g61ac9d8`) which can't be parsed by distutils `StrictVersion` class. To avoid this, the riak client library switched to using `LooseVersion`. We should probably do the same.
