### PR TITLE
Fix PBCTransport cleanup on pypy

### DIFF
--- a/riakasaurus/transport/pbc_transport.py
+++ b/riakasaurus/transport/pbc_transport.py
@@ -182,7 +182,8 @@ class PBCTransport(transport.FeatureDetection):
 
     @defer.inlineCallbacks
     def quit(self):
-        self._gc.cancel()      # cancel the garbage collector
+        if not self._gc.cancelled:
+            self._gc.cancel()      # cancel the garbage collector
 
         for stp in self._transports:
             if self.debug & LOGLEVEL_DEBUG:


### PR DESCRIPTION
`PBCTransport.__del__()` calls `PBCTransport.quit()` which tries to cancel `self._gc`. On pypy, `__del__` only gets called later and `self._gc` may already have been cancelled. This fix only cancels `self._gc` if it hasn't already been cancelled.

I don't really have a clear understanding of why the `__del__` is necessary in the first place and I suspect the whole connection pool thing could be dramatically simplified, but I don't really want to tackle that right now. (I'm happy to do it later if you decide that's a good idea, though.)
