### PR TITLE
Explicit unicode handling

### DIFF
--- a/riakasaurus/mapreduce.py
+++ b/riakasaurus/mapreduce.py
@@ -337,7 +337,7 @@ class RiakMapReducePhase(object):
         reduce function.
         """
         try:
-            if isinstance(function, basestring):
+            if isinstance(function, unicode):
                 function = function.encode('ascii')
         except UnicodeError:
             raise TypeError('Unicode encoded functions are not supported.')

--- a/riakasaurus/riak_object.py
+++ b/riakasaurus/riak_object.py
@@ -46,7 +46,8 @@ class RiakObject(object):
         :type key: string
         """
         try:
-            if isinstance(key, basestring):
+            # This allows non-ASCII bytestrings, which should be legal.
+            if isinstance(key, unicode):
                 key = key.encode('ascii')
         except UnicodeError:
             raise TypeError('Unicode keys are not supported.')

--- a/riakasaurus/tests/__init__.py
+++ b/riakasaurus/tests/__init__.py
@@ -1,0 +1,6 @@
+# Uncomment the following lines to disable Python's implicit unicode encoding
+# and decoding.
+
+# import sys
+# reload(sys)
+# sys.setdefaultencoding('undefined')

--- a/riakasaurus/tests/test_2i.py
+++ b/riakasaurus/tests/test_2i.py
@@ -76,7 +76,7 @@ class Tests(unittest.TestCase):
 
         r1 = yield results[0].get()
 
-        self.assertEqual(r1.get_key(), u'foo2')
+        self.assertEqual(r1.get_key(), 'foo2')
 
         log.msg("done secondary_index")
 
@@ -95,10 +95,32 @@ class Tests(unittest.TestCase):
         obj.add_index('field2_int', 1003)
         yield obj.store()
 
-        results = yield self.bucket.get_index('field2_int', 1,
-                                          2000)
+        results = yield self.bucket.get_index('field2_int', 1, 2000)
 
         self.assertEqual(sorted(results),
                          ['foo1', 'foo2'])
+
+        log.msg("done secondary_index")
+
+    @defer.inlineCallbacks
+    def test_non_ascii_keys(self):
+        log.msg("*** secondary_index")
+        yield self.bucket.enable_search()
+
+        obj = self.bucket.new('foo1', {'field1': 'val1', 'field2': 1001})
+        obj.add_index('field1_bin', 'val1')
+        obj.add_index('field2_int', 1001)
+        yield obj.store()
+
+        obj = self.bucket.new(
+            'foo\xe2\x98\x83', {'field1': 'val2', 'field2': 1003})
+        obj.add_index('field1_bin', 'val2')
+        obj.add_index('field2_int', 1003)
+        yield obj.store()
+
+        results = yield self.bucket.get_index('field2_int', 1, 2000)
+
+        self.assertEqual(sorted(results),
+                         ['foo1', 'foo\xe2\x98\x83'])
 
         log.msg("done secondary_index")

--- a/riakasaurus/tests/test_objects.py
+++ b/riakasaurus/tests/test_objects.py
@@ -69,7 +69,8 @@ class Tests(unittest.TestCase):
         yield obj.store()
 
         self.assertEqual(obj.exists(), True)
-        self.assertEqual(obj.get_data(), "bar1")
+        # We get unicode from .get_data() because the content type is JSON.
+        self.assertEqual(obj.get_data(), u"bar1")
         log.msg("done set_data_empty")
 
     @defer.inlineCallbacks
@@ -81,14 +82,16 @@ class Tests(unittest.TestCase):
         yield obj.store()
 
         self.assertEqual(obj.exists(), True)
-        self.assertEqual(obj.get_data(), "test1")
+        # We get unicode from .get_data() because the content type is JSON.
+        self.assertEqual(obj.get_data(), u"test1")
 
         obj.set_data('bar1')
         yield obj.store()
 
         obj = yield self.bucket.get("foo1")
         self.assertEqual(obj.exists(), True)
-        self.assertEqual(obj.get_data(), "bar1")
+        # We get unicode from .get_data() because the content type is JSON.
+        self.assertEqual(obj.get_data(), u"bar1")
 
         yield obj.delete()
 
@@ -107,7 +110,7 @@ class Tests(unittest.TestCase):
         yield obj1.store()
 
         keys = yield self.bucket.list_keys()
-        self.assertEqual([u"foo1", u"foo2"], sorted(keys))
+        self.assertEqual(["foo1", "foo2"], sorted(keys))
 
     @defer.inlineCallbacks
     def test_purge_keys(self):
@@ -145,7 +148,8 @@ class Tests(unittest.TestCase):
         self.assertEqual(obj1.exists(), True)
         self.assertEqual(obj1.get_bucket().get_name(), self.bucket_name)
         self.assertEqual(obj1.get_key(), 'blue_foo1')
-        self.assertEqual(obj1.get_data(), data)
+        # We get unicode from .get_data() because the content type is JSON.
+        self.assertEqual(obj1.get_data(), u'blueprint')
         log.msg('done store_and_get')
 
     @defer.inlineCallbacks

--- a/riakasaurus/tests/test_search.py
+++ b/riakasaurus/tests/test_search.py
@@ -80,7 +80,7 @@ class Tests(unittest.TestCase):
 
         v1 = yield keys[0].get()
 
-        self.assertTrue(v1.get_key() == u'foo1')
+        self.assertTrue(v1.get_key() == 'foo1')
 
         yield obj1.delete()
         yield self.bucket.disable_search()
@@ -130,8 +130,8 @@ class Tests(unittest.TestCase):
         results = yield self.client.solr().search(self.bucket_name,
                                                   "username:tony")
 
-        self.assertEquals("tony",
-                          results["docs"][0]["username"])
+        self.assertEquals(u"tony",
+                          results["docs"][0][u"username"])
 
     @defer.inlineCallbacks
     def test_add_multiple_documents_to_index(self):

--- a/riakasaurus/transport/http_transport.py
+++ b/riakasaurus/transport/http_transport.py
@@ -249,7 +249,10 @@ class HTTPTransport(transport.FeatureDetection):
         else:
             raise Exception('Error getting bucket properties.')
 
-        defer.returnValue(props['keys'])
+        # We encode to UTF-8 here, because Riak decodes from UTF-8 to get
+        # unicode for the JSON response.
+        keys = [key.encode('utf-8') for key in props[u'keys']]
+        defer.returnValue(keys)
 
     @defer.inlineCallbacks
     def set_bucket_props(self, bucket, props):
@@ -310,7 +313,7 @@ class HTTPTransport(transport.FeatureDetection):
     def _server_version(self):
         stats = yield self.stats()
         if stats is not None:
-            defer.returnValue(stats['riak_kv_version'])
+            defer.returnValue(stats[u'riak_kv_version'].encode('ascii'))
         # If stats is disabled, we can't assume the Riak version
         # is >= 1.1. However, we can assume the new URL scheme is
         # at least version 1.0
@@ -473,7 +476,10 @@ class HTTPTransport(transport.FeatureDetection):
         else:
             raise Exception('Error getting buckets.')
 
-        defer.returnValue(props['buckets'])
+        # We encode to UTF-8 here, because Riak decodes from UTF-8 to get
+        # unicode for the JSON response.
+        buckets = [key.encode('utf-8') for key in props[u'buckets']]
+        defer.returnValue(buckets)
 
     @defer.inlineCallbacks
     def get_bucket_props(self, bucket):
@@ -489,7 +495,9 @@ class HTTPTransport(transport.FeatureDetection):
         encoded_props = response[1]
         if headers['http_code'] == 200:
             props = self.decodeJson(encoded_props)
-            defer.returnValue(props['props'])
+            byte_key_props = dict(
+                (k.encode('utf-8'), v) for k, v in props[u'props'].items())
+            defer.returnValue(byte_key_props)
         else:
             raise Exception('Error getting bucket properties.')
 
@@ -558,7 +566,10 @@ class HTTPTransport(transport.FeatureDetection):
         self.check_http_code(response, [200])
         jsonData = self.decodeJson(data)
 
-        defer.returnValue(jsonData[u'keys'][:])
+        # We encode to UTF-8 here, because Riak decodes from UTF-8 to get
+        # unicode for the JSON response.
+        keys = [key.encode('utf-8') for key in jsonData[u'keys']]
+        defer.returnValue(keys)
 
     @defer.inlineCallbacks
     def search(self, index, query, **params):


### PR DESCRIPTION
I ran the test suite with the default encoding set to `'undefined'` (see `riakasaurus/tests/__init__.py` for that) and added explicit encoding and decoding to all the places that needed them.

There are still two tests that fail with encoding errors, but the implicit conversion happens in the bowels of Python's standard library (`xml.etree`, to be exact) and there's nothing we can do about it here.
